### PR TITLE
Bump npm version to package.json's version if it is higher

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This will look in `packages/*` for packages which have _any_ changes based on th
   - deployed via [`vsce`](https://code.visualstudio.com/api/working-with-extensions/publishing-extension) when there is a `VSCE_TOKEN` in the env
   - deployed via [`ovsx`](https://www.npmjs.com/package/ovsx) when there is a `OVSX_TOKEN` in the env
 
-It will grab the latest semver number from either npm or the vscode marketplace, and then bump it by a patch,
+It will grab the latest semver number from either npm or the vscode marketplace, and then bump it by a patch. For npm, if the project's `package.json` version is higher than that on npm, it will use that version instead.
 
 ```yml
 name: Deploy Daily Builds

--- a/src/bumping/npm.ts
+++ b/src/bumping/npm.ts
@@ -7,12 +7,12 @@ const axios = require("axios").default;
 
 const getPackageVersion = async (packageMD: PackageMetadata) => {
   try {
-    const npmInfo = await axios({ url:`https://registry.npmjs.org/${packageMD.name}`, method: "GET" });
+    const npmInfo = await axios({ url: `https://registry.npmjs.org/${packageMD.name}`, method: "GET" });
     if (!npmInfo.data || !npmInfo.data._id) {
       throw new Error("Got a bad response from NPM");
-    } 
+    }
     return npmInfo.data['dist-tags'].latest;
-    
+
   } catch (error) {
     console.log(`${packageMD.name} is a new package, starting from version in package.json`)
     const pkgPath = join(packageMD.path, "package.json");
@@ -21,17 +21,36 @@ const getPackageVersion = async (packageMD: PackageMetadata) => {
   }
 };
 
+const isPackageJSONVersionHigher = (packageJSONVersion: string, bumpedVersion: string) => {
+  const semverMarkersPackageJSON = packageJSONVersion.split(".");
+  const semverMarkersBumped = bumpedVersion.split(".");
+  for (let i = 0; i < 3; i++) {
+    if (Number(semverMarkersPackageJSON[i]) > Number(semverMarkersBumped[i])) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+const bumpPatch = (version: string) => {
+  const semverMarkers = version.split(".");
+  return `${semverMarkers[0]}.${semverMarkers[1]}.${Number(semverMarkers[2]) + 1}`;
+}
+
 export const bumpVersionNPM = async (packageMD: PackageMetadata) => {
   const version = await getPackageVersion(packageMD);
   if (!version) throw new Error("Could not find the npm version in the registry");
 
-  const semverMarkers = version.split(".");
-  const newVersion = `${semverMarkers[0]}.${semverMarkers[1]}.${Number(semverMarkers[2]) + 1}`;
-
   const pkgPath = join(packageMD.path, "package.json");
-  const oldPackageJSON = JSON.parse(readFileSync(pkgPath, "utf8"));
-  oldPackageJSON.version = newVersion;
-  writeFileSync(pkgPath, JSON.stringify(oldPackageJSON));
+  const packageJSON = JSON.parse(readFileSync(pkgPath, "utf8"));
+
+  const newVersion = isPackageJSONVersionHigher(packageJSON.version, version)
+    ? packageJSON.version
+    : bumpPatch(version);
+
+  packageJSON.version = newVersion;
+  writeFileSync(pkgPath, JSON.stringify(packageJSON));
 
   console.log(`Updated ${packageMD.name} to ${newVersion} from npm`);
 };


### PR DESCRIPTION
This enables users to bump the minor/major versions "by hand", if they want to.

Example:

npm version is `0.1.123`
`package.json` is `0.2.0`
--> new version now is `0.2.0` instead of `0.1.124`