### PR TITLE
Adds support for vscode preview builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ For a weekly deploy, with npm installs, a custom sort order and only specific pa
           install: 'true'
 ```
 
+Deploy nightly builds for vscode extensions [which get deployed as pre-releases](https://code.visualstudio.com/updates/v1_63#_pre-release-extensions):
+
+
+```yml
+      - uses: orta/monorepo-deploy-nightly@master
+        env:
+          VSCE_TOKEN: ${{ secrets.AZURE_PAN_TOKEN }}
+        with: 
+          preview: 'true'
+```
 
 ### TODO
 

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'JS Monorepo Deploy Nightly'
-description: 'Deploys packages/* npm/vscode packages when the change'
+description: 'Deploys packages/* for npm/vscode packages when they change'
 author: 'Orta Therox'
 inputs:
   since:
@@ -15,6 +15,9 @@ inputs:
     description: 'The sort order for the deploy process based on the names of the packages, expected to be a JSON.parse-able array of string.'
   only:
     description: 'If you only want to deploy specific packages, list them here.'
+  preview:
+    default: 'false'
+    description: 'Only currently works for vscode extensions, it will deploy those with --pre-release'
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -472,7 +472,8 @@ function deploy(packageMetadata, settings) {
             console.log(`\n\n# Deploying ${packageMD.name}.`);
             if (packageMD.type === 'vscode') {
                 if (process.env.VSCE_TOKEN) {
-                    exec(`npx vsce publish -p ${process.env.VSCE_TOKEN}`);
+                    const suffix = settings.preview ? "--pre-release" : "";
+                    exec(`npx vsce publish -p ${process.env.VSCE_TOKEN} ${suffix}`);
                 }
                 if (process.env.OVSX_TOKEN) {
                     exec(`npx ovsx publish -p ${process.env.OVSX_TOKEN}`);
@@ -540,7 +541,8 @@ function getPackageMetadata(changedPackages, settings) {
             packageJSON: json,
             type,
             isPrivate,
-            dirname: packagePath
+            dirname: packagePath,
+            preview: settings.preview
         });
     });
     return packageMetadata;
@@ -1103,17 +1105,20 @@ function run() {
             const sort = JSON.parse(core.getInput('sort')) || [];
             const install = !!core.getInput('install') || false;
             const only = JSON.parse(core.getInput('only'));
+            const preview = JSON.parse(core.getInput('preview')) || false;
             const settings = {
                 since,
                 cwd,
                 sort,
                 install,
-                only
+                only,
+                preview
             };
             yield runner_1.runDeployer(settings);
         }
         catch (error) {
-            core.setFailed(error.message);
+            const err = error;
+            core.setFailed(err.message);
         }
     });
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,18 +8,21 @@ async function run(): Promise<void> {
     const sort = JSON.parse(core.getInput('sort')) || []
     const install = !!core.getInput('install') || false
     const only = JSON.parse(core.getInput('only'))
+    const preview = JSON.parse(core.getInput('preview')) || false
 
     const settings: RunSettings = {
       since,
       cwd,
       sort,
       install,
-      only
+      only,
+      preview
     }
 
     await runDeployer(settings)
   } catch (error) {
-    core.setFailed(error.message)
+    const err = error as any
+    core.setFailed(err.message)
   }
 }
 


### PR DESCRIPTION
Adds support for `with: preview: true` which allows you to send builds to a preview version of the extension.